### PR TITLE
Alpine image Dockerfile

### DIFF
--- a/alpine-domain_stats/Dockerfile
+++ b/alpine-domain_stats/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine
+
+MAINTAINER Roy Sprague roy.sprague@gmail.com
+
+RUN apk add --update --no-cache --virtual .build-deps \
+      && apk add --no-cache --virtual .build-deps \
+        build-base \
+        git \
+        mercurial \
+        py2-pip \
+      && apk add --update --no-cache python2 \
+      && pip install PySocks \
+      && rm -rf /var/cache/apk/* \
+      && hg clone https://bitbucket.org/richardpenman/pywhois \
+      && chmod +x pywhois/setup.py \
+      && cd pywhois && python setup.py install && cd / \
+      && rm -rf /pywhois \
+      && mkdir /opt && cd /opt && git clone https://github.com/MarkBaggett/domain_stats.git \
+      && wget http://s3.amazonaws.com/alexa-static/top-1m.csv.zip \
+      && rm -rf /opt/domain_stats/top-1m.csv \
+      && unzip -o top-1m.csv.zip -d /opt/domain_stats \
+      && rm top-1m.csv.zip \
+      && find /usr/local \
+          \( -type d -a -name test -o -name tests \) \
+          -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+          -exec rm -rf '{}' + \
+      && runDeps="$( \
+          scanelf --needed --nobanner --recursive /usr/local \
+                  | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+                  | sort -u \
+                  | xargs -r apk info --installed \
+                  | sort -u \
+      )" \
+      && apk add --virtual .rundeps $runDeps \
+      && apk del .build-deps \ 
+      && mkdir /var/log/domain_stats \
+      && ln -sf /dev/stderr /var/log/domain_stats/domain_stats.log \
+      && adduser -Ds /bin/sh domain_stats \
+      && chown -R domain_stats: /opt/domain_stats
+
+USER domain_stats
+
+EXPOSE 20000
+
+STOPSIGNAL SIGTERM
+
+CMD /usr/bin/python /opt/domain_stats/domain_stats.py -ip 0.0.0.0 20000 -a /opt/domain_stats/top-1m.csv --preload 0

--- a/alpine-domain_stats/README.md
+++ b/alpine-domain_stats/README.md
@@ -1,0 +1,47 @@
+FROM alpine
+
+MAINTAINER Roy Sprague roy.sprague@gmail.com
+
+RUN apk add --update --no-cache --virtual .build-deps \
+      && apk add --no-cache --virtual .build-deps \
+        build-base \
+        git \
+        mercurial \
+        py2-pip \
+      && apk add --update --no-cache python2 \
+      && pip install PySocks \
+      && rm -rf /var/cache/apk/* \
+      && hg clone https://bitbucket.org/richardpenman/pywhois \
+      && chmod +x pywhois/setup.py \
+      && cd pywhois && python setup.py install && cd / \
+      && rm -rf /pywhois \
+      && mkdir /opt && cd /opt && git clone https://github.com/MarkBaggett/domain_stats.git \
+      && wget http://s3.amazonaws.com/alexa-static/top-1m.csv.zip \
+      && rm -rf /opt/domain_stats/top-1m.csv \
+      && unzip -o top-1m.csv.zip -d /opt/domain_stats \
+      && rm top-1m.csv.zip \
+      && find /usr/local \
+          \( -type d -a -name test -o -name tests \) \
+          -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+          -exec rm -rf '{}' + \
+      && runDeps="$( \
+          scanelf --needed --nobanner --recursive /usr/local \
+                  | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+                  | sort -u \
+                  | xargs -r apk info --installed \
+                  | sort -u \
+      )" \
+      && apk add --virtual .rundeps $runDeps \
+      && apk del .build-deps \ 
+      && mkdir /var/log/domain_stats \
+      && ln -sf /dev/stderr /var/log/domain_stats/domain_stats.log \
+      && adduser -Ds /bin/sh domain_stats \
+      && chown -R domain_stats: /opt/domain_stats
+
+USER domain_stats
+
+EXPOSE 20000
+
+STOPSIGNAL SIGTERM
+
+CMD /usr/bin/python /opt/domain_stats/domain_stats.py -ip 0.0.0.0 20000 -a /opt/domain_stats/top-1m.csv --preload 0

--- a/alpine-domain_stats/README.md
+++ b/alpine-domain_stats/README.md
@@ -1,47 +1,18 @@
-FROM alpine
+# alpine-domainstats Builder
 
-MAINTAINER Roy Sprague roy.sprague@gmail.com
+Domain analysis service
 
-RUN apk add --update --no-cache --virtual .build-deps \
-      && apk add --no-cache --virtual .build-deps \
-        build-base \
-        git \
-        mercurial \
-        py2-pip \
-      && apk add --update --no-cache python2 \
-      && pip install PySocks \
-      && rm -rf /var/cache/apk/* \
-      && hg clone https://bitbucket.org/richardpenman/pywhois \
-      && chmod +x pywhois/setup.py \
-      && cd pywhois && python setup.py install && cd / \
-      && rm -rf /pywhois \
-      && mkdir /opt && cd /opt && git clone https://github.com/MarkBaggett/domain_stats.git \
-      && wget http://s3.amazonaws.com/alexa-static/top-1m.csv.zip \
-      && rm -rf /opt/domain_stats/top-1m.csv \
-      && unzip -o top-1m.csv.zip -d /opt/domain_stats \
-      && rm top-1m.csv.zip \
-      && find /usr/local \
-          \( -type d -a -name test -o -name tests \) \
-          -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-          -exec rm -rf '{}' + \
-      && runDeps="$( \
-          scanelf --needed --nobanner --recursive /usr/local \
-                  | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-                  | sort -u \
-                  | xargs -r apk info --installed \
-                  | sort -u \
-      )" \
-      && apk add --virtual .rundeps $runDeps \
-      && apk del .build-deps \ 
-      && mkdir /var/log/domain_stats \
-      && ln -sf /dev/stderr /var/log/domain_stats/domain_stats.log \
-      && adduser -Ds /bin/sh domain_stats \
-      && chown -R domain_stats: /opt/domain_stats
+This builder image constructs a Alpine Linux image for a minimalistic image.  The image should consist of only the needed dependancies for domain_stats.  It includes the latest version of pywhois which has support for a SOCKS proxy.  It also includes the latest version to top-1m.csv.
 
-USER domain_stats
+SOCKS Proxy support requirements:
 
-EXPOSE 20000
+     #Add the following to the docker run script
+     #The environment variable for SOCKS if needed to utilize a SOCKS5 proxy.
+     $  docker run --name=so-domainstats \
+                        --detach \
+                        --volume /var/log/domain_stats:/var/log/domain_stats \
+                        -e SOCKS=someplace.proxy.com:1080 \
+                        alpine-domainstats
 
-STOPSIGNAL SIGTERM
-
-CMD /usr/bin/python /opt/domain_stats/domain_stats.py -ip 0.0.0.0 20000 -a /opt/domain_stats/top-1m.csv --preload 0
+     # Logstash will connect to DomainStats over $DOCKERNET
+     docker network connect --alias domainstats $DOCKERNET so-domainstats


### PR DESCRIPTION
Justin, the alpine-domain_stats/Dockerfile will build a Docker image that is less than 90MB for domain_stats vs the +300MB image.  It includes the latest version of whois that supports the use of a SOCKS proxy.  This is a considerably smaller image with a lot less attack surface within the image vs the centos image.  I've tested and currently running in my SO lab without any issues.  